### PR TITLE
Add nxt-1.61.1 and nxt-1.65.1 support to existing instruction set.

### DIFF
--- a/NextionInstructionSets.py
+++ b/NextionInstructionSets.py
@@ -321,7 +321,7 @@ all_instruction_sets = [
     },
     {
         'versions': [
-            'nxt-1.63.1', 'nxt-1.63.2', 'nxt-1.63.3',
+            'nxt-1.61.1', 'nxt-1.63.1', 'nxt-1.63.2', 'nxt-1.63.3', 'nxt-1.65.1',
         ],
         'models': {
             0: {


### PR DESCRIPTION
The Example tft will now parse.

It's possible there are some new instructions in 1.65.1, but added it to the existing set just so I could unblock a conversion I wanted with a TFT built with 1.65.1

I confirmed it worked by creating a TFT from an HMI with Nextion Editor 1.65.1, then using this code to convert it to a TJC device, then loaded that firmware on a TJC device and booted it. 